### PR TITLE
Fix Scramble

### DIFF
--- a/wdl/Scramble.wdl
+++ b/wdl/Scramble.wdl
@@ -169,8 +169,11 @@ task RunScramble {
               "GT","0/1" }' xyzzy???_PredictedDeletions.txt >> tmp.vcf
     fi
 
+    # Remove HLA contigs to avoid bcftools error "[W::vcf_parse] Contig 'HLA-DRB1*10' is not defined in the header"
+    grep -v ^HLA tmp.vcf > tmp-nohla.vcf
+
     # sort and index the output VCF
-    bcftools sort -Oz <tmp.vcf >"~{sample_name}.scramble.vcf.gz"
+    bcftools sort -Oz <tmp-nohla.vcf >"~{sample_name}.scramble.vcf.gz"
     bcftools index -ft "~{sample_name}.scramble.vcf.gz"
   >>>
   runtime {

--- a/wdl/Scramble.wdl
+++ b/wdl/Scramble.wdl
@@ -61,7 +61,7 @@ task RunScramble {
     File? NOT_A_FILE
   }
 
-  Int mem_size_gb = if detect_deletions then 16 else 3
+  Int mem_size_gb = if detect_deletions then 32 else 6
   Int disk_size_gb = ceil(size(bam_or_cram_file,"GiB") + size(bam_or_cram_index,"GiB") + size(reference_fasta,"GiB") + 10)
 
   RuntimeAttr default_attr = object {


### PR DESCRIPTION
1. Drop HLA contigs from VCF to avoid:

```
Writing to /tmp/bcftools-sort.CBfZdQ
[W::vcf_parse] Contig 'HLA-DRB1*10' is not defined in the header. (Quick workaround: index the file with tabix.)
Error encountered while parsing the input at HLA-DRB1*10:2
```

HLA contig names are not well standardised, and even using the same reference build, `SN:HLA-DRB1*10:01:01` in the reference genome somehow turns into `HLA-DRB1*10` in a VCF. I don't think anything in GATK-SV does HLA typing, so it's safe to just drop them.

2. Add more memory to the task to avoid OOM for SCRAMble.R: 

```
/cromwell_root/script: line 119:    19 Killed                  Rscript --vanilla $scrambleDir/cluster_analysis/bin/SCRAMble.R --out-name $clusterFile --cluster-file $clusterFile --install-dir $scrambleDir/cluster_analysis/bin --mei-refs $meiRef --ref $xDir/ref --no-vcf --eval-meis
```