### PR TITLE
ClusterBatch: pass contig list to PreparePESRVcfs VCF preprocessing

### DIFF
--- a/wdl/PESRClustering.wdl
+++ b/wdl/PESRClustering.wdl
@@ -163,6 +163,7 @@ task PreparePESRVcfs {
       SAMPLE_NUM=`printf %05d $i`
 
       # Keep main contigs only
+      bcftools index $VCF
       bcftools view $VCF --regions ~{sep=',' contigs} -Oz -o tmp1.vcf.gz
 
       # Convert format


### PR DESCRIPTION
Fixes errors like this in `ClusterBatch/call-ClusterPESR_scramble/ClusterPESR/PreparePESRVcfs`:

```/cromwell_root/script
Traceback (most recent call last):
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 267, in <module>
    main()
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 254, in main
    vcf_out.write(convert(
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 166, in convert
    new_genotype['ECN'] = ploidy_dict[sample][contig]
KeyError: 'chr14_GL000225v1_random' 
```

When a VCF contains non-primary contigs.

Tetst https://batch.hail.populationgenomics.org.au/batches/377137