### PR TITLE
Remove Token reference

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -132,11 +132,10 @@ jobs:
         run: |
           cd ./scripts/docker/
           python build_docker.py \
-            --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
             --docker-repo australia-southeast1-docker.pkg.dev/cpg-common/images \
-            --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
-            --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
+            --targets wham str sv-pipeline-virtual-env sv-pipeline sv-utils \
             --prune-after-each-image \
+            --image-tag v0.28.1 \
             --dry-run
 
   publish_job:
@@ -197,10 +196,10 @@ jobs:
         id: build_and_publish
         run: |
           python ./scripts/docker/build_docker.py \
-            --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
-            --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
             --docker-repo australia-southeast1-docker.pkg.dev/cpg-common/images \
-            --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
+            --targets wham str sv-pipeline-virtual-env sv-pipeline sv-utils \
+            --prune-after-each-image \
+            --image-tag v0.28.1 \
             --input-json $DOCKERS_GCP \
             --output-json $DOCKERS_GCP
           

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -160,8 +160,6 @@ jobs:
         with:
           # See the comment on build_args_job.
           fetch-depth: 0
-          # Authenticates git using the bot's access token.
-          token: ${{ secrets.BOT_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
Removes the GitHub bot access token - we don't use this in an auto-committing workflow