### PR TITLE
remove git protection during build

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -201,7 +201,8 @@ jobs:
             --prune-after-each-image \
             --image-tag v0.28.1 \
             --input-json $DOCKERS_GCP \
-            --output-json $DOCKERS_GCP
+            --output-json $DOCKERS_GCP \
+            --disable-git-protect
           
           CHANGED=$(git diff --quiet $DOCKERS_GCP || echo True)
           echo "::set-output name=CHANGED::$CHANGED"


### PR DESCRIPTION
Sorry for the mayhem - 

The latest build workflow failed because there were uncommitted files in the repo. That's not really possible, as the code is freshly checked out during the workflow. 

[This comment](https://github.com/broadinstitute/gatk-sv/blob/main/.github/workflows/sv_pipeline_docker.yml#L182-L188C59) suggests that an uncontrolled file is the result of a GCP authentication process, so the check needs to be disabled. We didn't have this flag set during the last successful build run in our CI, not sure why it's a problem now. 