### PR TITLE
Update gcloud auth command for Wham

### DIFF
--- a/wdl/Whamg.wdl
+++ b/wdl/Whamg.wdl
@@ -251,7 +251,7 @@ task RunWhamgOnCram {
     echo "whamg $(whamg 2>&1 | grep Version)"
 
     # necessary for getting permission to read from google bucket directly
-    export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
+    export GCS_OAUTH_TOKEN=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
 
     # covert cram to bam
     samtools view -b1@ ~{cpu_cores} -T "~{reference_fasta}" "~{cram_file}" > sample.bam


### PR DESCRIPTION
Our GATK-SV single sample variant calling on Google Batch API jobs are busted - during the Wham variant calling stage the workflow attempts a `gcloud auth` call, but the python installation isn't on the expected path, which causes a failure. Another user has identified this change as a fix, and Cromwell have patched at source, but won't have a new release for quite a while. 

See: https://github.com/broadinstitute/gatk-sv/issues/798

Internal Thread: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1751868036314189?thread_ts=1751848994.801689&cid=C018KFBCR1C

This issue has been patched in Cromwell, but didn't make it into the V90 release (which we recently moved up to). Once that's released we could remove this change, re-sync with upstream, and be happy.